### PR TITLE
Initialize CI/CD sample project

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "root": true,
+  "env": {
+    "es2020": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "ignorePatterns": ["dist/**", "public/**"],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: npm test
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: npm run coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: npm run docs
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    environment:
+      name: production
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+
+  preview:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    environment:
+      name: pr-${{ github.head_ref }}
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+public/
+coverage/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,78 @@
+stages:
+  - lint
+  - test
+  - coverage
+  - build
+  - deploy
+
+lint:
+  stage: lint
+  image: node:lts
+  script:
+    - npm install
+    - npm run lint
+
+unit_test:
+  stage: test
+  image: node:lts
+  script:
+    - npm install
+    - npm test
+
+coverage:
+  stage: coverage
+  image: node:lts
+  script:
+    - npm install
+    - npm run coverage
+  artifacts:
+    paths:
+      - coverage
+
+build:
+  stage: build
+  image: node:lts
+  script:
+    - npm install
+    - npm run docs
+    - npm run build
+  artifacts:
+    paths:
+      - public
+
+review:
+  stage: deploy
+  image: node:lts
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    on_stop: stop_review
+  script:
+    - echo "Review app"
+  only:
+    - branches
+  except:
+    - main
+
+stop_review:
+  stage: deploy
+  image: node:lts
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    action: stop
+  script: []
+  when: manual
+  only:
+    - branches
+
+pages:
+  stage: deploy
+  image: node:lts
+  script:
+    - echo "Deploy pages"
+  artifacts:
+    paths:
+      - public
+  dependencies:
+    - build
+  only:
+    - main

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# cicd-sample
+# CI/CD Sample Project
+
+This repository demonstrates a minimal pipeline that works on both GitHub Actions and GitLab CI. It includes linting, testing with coverage, documentation generation, TypeScript build, and static site deployment.
+
+## Usage
+
+```bash
+npm install
+npm run lint
+npm test
+npm run coverage
+npm run docs
+npm run build
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,9 @@
+# API Documentation
+
+## greet()
+
+Description TBD.
+
+## add()
+
+Description TBD.

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,4 @@
+```mermaid
+graph TD
+  A[Client] --> B[Server]
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,17 @@
+let plugin;
+let parser;
+try {
+  plugin = (await import('@typescript-eslint/eslint-plugin')).default;
+  parser = (await import('@typescript-eslint/parser')).default;
+} catch {
+  console.warn('TS ESLint deps missing');
+}
+
+export default [
+  {
+    files: ['src/**/*.{ts,js}'],
+    ...(parser ? { languageOptions: { parser, parserOptions: { sourceType: 'module' } } } : {}),
+    plugins: plugin ? { '@typescript-eslint': plugin } : {},
+    rules: {},
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "cicd-sample",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint \"src/**/*.{ts,js}\"",
+    "pretest": "tsc",
+    "test": "node --test --experimental-test-coverage",
+    "coverage": "c8 --reporter=html npm run test",
+    "docs": "typedoc --plugin typedoc-plugin-markdown --out docs/api src || node scripts/generate-docs.mjs",
+    "build": "tsc && cp -R src public && cp -R docs public"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "prettier": "^3.0.0",
+    "c8": "^8.0.1",
+    "typedoc": "^0.25.0",
+    "typedoc-plugin-markdown": "^3.14.0",
+    "typescript": "^5.4.0"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -1,0 +1,22 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+async function main() {
+  const src = await fs.readFile('src/main.ts', 'utf8');
+  const lines = src.split('\n');
+  const docLines = ['# API Documentation', ''];
+  for (const line of lines) {
+    const match = line.match(/^export function (\w+)/);
+    if (match) {
+      const name = match[1];
+      docLines.push(`## ${name}()`);
+      docLines.push('');
+      docLines.push('Description TBD.');
+      docLines.push('');
+    }
+  }
+  await fs.mkdir('docs/api', { recursive: true });
+  await fs.writeFile('docs/api/index.md', docLines.join('\n'));
+}
+
+main();

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CI/CD Sample</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1 id="app">Loading...</h1>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,1 @@
+body { font-family: sans-serif; text-align: center; }

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { add, greet } from '../dist/main.js';
+
+describe('main', () => {
+  it('greet', () => {
+    assert.strictEqual(greet('World'), 'Hello, World!');
+  });
+  it('add', () => {
+    assert.strictEqual(add(1, 2), 3);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add sample TypeScript source and docs
- configure linting and testing
- set up GitHub Actions and GitLab CI pipelines
- provide fallback doc generation script
- use npm install in CI and update artifact actions
- add ignore file and compile before tests

## Testing
- `node scripts/generate-docs.mjs`
- `npm test`
- `npm run build`
