### PR TITLE
Fix index and lint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -3,6 +3,7 @@ module.exports = [
     files: ['**/*.{ts,js}'],
     ignores: ['dist/**', 'public/**'],
     languageOptions: {
+      parser: require('@typescript-eslint/parser'),
       ecmaVersion: 'latest',
       sourceType: 'module',
     },

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <h1 id="app">Loading...</h1>
-  <script type="module" src="main.js"></script>
+  <script type="module" src="main.ts"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reference `main.ts` from index.html
- configure ESLint parser for TypeScript

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test`